### PR TITLE
Adding required offset parameters

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -39,7 +39,7 @@ MIDIStream.prototype.addData = function (data) {
 			return;
 		}
 
-		if (this.buffer.readUInt32BE() === constants.START_OF_FILE) {
+		if (this.buffer.readUInt32BE(0) === constants.START_OF_FILE) {
 			if (this.buffer.length < constants.FILE_HEADER_LENGTH) {
 				// We cannot read the header yet.
 				return;

--- a/writer.js
+++ b/writer.js
@@ -31,7 +31,7 @@ Writer.prototype.startFile = function (fileType, noTracks, ticks, cb) {
 	}
 
 	var buffer = new Buffer(constants.FILE_HEADER_LENGTH);
-	buffer.writeInt32BE(constants.START_OF_FILE);
+	buffer.writeInt32BE(constants.START_OF_FILE, 0);
 	buffer.writeInt32BE(0x6, 4);
 	buffer.writeInt16BE(fileType, 8);
 	buffer.writeInt16BE(noTracks, 10);
@@ -42,7 +42,7 @@ Writer.prototype.startFile = function (fileType, noTracks, ticks, cb) {
 
 Writer.prototype.startTrack = function (size, cb) {
 	var buffer = new Buffer(constants.TRACK_HEADER_LENGTH);
-	buffer.writeInt32BE(constants.START_OF_TRACK);
+	buffer.writeInt32BE(constants.START_OF_TRACK, 0);
 	if (!size) {
 		size = 0;
 	}


### PR DESCRIPTION
Hi Joel,

Seems that the offset parameter is required when reading/writing on a Buffer. On node v0.12.7, it throws an error if it's not specified.
